### PR TITLE
format definition made safe, added configurable row delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Easily create fixed width text stream/files with node.js
 ```javascript
 var Fixated = require('Fixated');
 
-var format = {
-  firstName: 15,
-  lastName: 15,
-  address: 200,
-};
+var format = [
+  [firstName, 15],
+  [lastName, 15],
+  [address, 200],
+];
 
 var fixated = new Fixated(format);
 fixated.pipe(require('fs').createWriteStream('./out.txt');


### PR DESCRIPTION
Hi I made two changes to your code.

1 format definition:
I changed the format-definition from object to array (see readme). Reason: The code seems to rely the assumption, that the order of parameters in objects is defined. However, Javascript does not gurantee that the order is defined, even though in practice it is. Using an array is safe in that respect.

2 row delimiter
can now be configured as part of the options.
